### PR TITLE
Implement modern theme

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -5,6 +5,10 @@
   <title>Admin QR Tracker - Campagnes</title>
   
   <!-- CSS -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/admin.css">
   
   <!-- Bibliothèques externes -->

--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -7,8 +7,8 @@
 
 body {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background: #ffffff;
-  color: #000000;
+  background: var(--background);
+  color: var(--text);
   line-height: 1.6;
   font-size: 14px;
   font-weight: 400;
@@ -17,11 +17,11 @@ body {
 
 /* Palette de couleurs */
 :root {
-  --primary: #000000;
-  --secondary: #666666;
+  --primary: var(--text);
+  --secondary: var(--muted);
   --light-gray: #f2f2f2;
-  --border: #e5e5e5;
-  --accent: #4A90E2; /* Bleu léger et élégant */
+  --border: var(--border);
+  --accent: var(--accent);
   --hover: #fafafa;
 }
 

--- a/public/css/scanner.css
+++ b/public/css/scanner.css
@@ -6,8 +6,8 @@
 
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  background: #f8f8f8;
-  color: #1a1a1a;
+  background: var(--background);
+  color: var(--text);
   min-height: 100vh;
   display: flex;
   align-items: center;
@@ -44,7 +44,7 @@ h1 {
 
 .location {
   font-weight: 700;
-  color: #0066ff;
+  color: var(--accent);
   font-size: 20px;
   display: block;
   margin-top: 8px;
@@ -52,7 +52,7 @@ h1 {
 
 .scan-button {
   width: 100%;
-  background: #0066ff;
+  background: var(--accent);
   color: #fff;
   border: none;
   padding: 16px 24px;
@@ -67,7 +67,7 @@ h1 {
 }
 
 .scan-button:hover {
-  background: #0052d4;
+  background: var(--accent-hover);
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(0, 102, 255, 0.2);
 }

--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -1,0 +1,35 @@
+:root {
+  --background: #ffffff;
+  --text: #000000;
+  --accent: #0066ff;
+  --accent-hover: #004bb5;
+  --border: #e5e5e5;
+  --muted: #666666;
+}
+
+body {
+  background: var(--background);
+  color: var(--text);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-size: 14px;
+}
+
+button, .btn, a {
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.btn,
+button {
+  background-color: var(--accent);
+  color: #fff;
+  border: none;
+  padding: 10px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.btn:hover,
+button:hover {
+  background-color: var(--accent-hover);
+}

--- a/public/scanner.html
+++ b/public/scanner.html
@@ -7,6 +7,10 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="theme-color" content="#0066ff">
   <title>Scanner QR Code</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/scanner.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- create a shared `theme.css` to define a modern black & white layout with blue highlights
- load the new theme and Google font in `admin.html` and `scanner.html`
- use CSS variables from the theme in `admin.css` and `scanner.css`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840c43e65f4832a9cdf3ad38d664adc