### PR TITLE
Add scan limit Jest test

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "start": "node server.js"
   },
   "keywords": [],

--- a/tests/scans.test.js
+++ b/tests/scans.test.js
@@ -1,0 +1,65 @@
+const fs = require('fs');
+const blockchainModule = require('../modules/blockchain');
+
+jest.mock('fs');
+jest.mock('../modules/blockchain', () => ({
+  recordScanOnBlockchain: jest.fn((data, cb) => cb(null, {}))
+}));
+
+const scans = require('../modules/scans');
+
+describe('processScan passage mode limits', () => {
+  beforeEach(() => {
+    fs.existsSync.mockReset();
+    fs.readFileSync.mockReset();
+    fs.writeFileSync.mockReset();
+    blockchainModule.recordScanOnBlockchain.mockClear();
+  });
+
+  test('responds 409 when uuid exceeds max scans', () => {
+    const campaigns = [{
+      type: 'test',
+      enabled: true,
+      qrs: [{
+        location: 'loc1',
+        location_id: 'loc1',
+        enabled: true,
+        mode: 'passage',
+        max_scans_per_uuid: 2
+      }]
+    }];
+
+    const logs = [
+      { uuid: '123', location_id: 'loc1', scan_type: 'test', timestamp: 1 },
+      { uuid: '123', location_id: 'loc1', scan_type: 'test', timestamp: 2 }
+    ];
+
+    fs.existsSync.mockImplementation((filePath) => true);
+    fs.readFileSync.mockImplementation((filePath) => {
+      if (filePath.includes('campaigns')) {
+        return JSON.stringify(campaigns);
+      }
+      if (filePath.includes('scanlogs')) {
+        return JSON.stringify(logs);
+      }
+      return '[]';
+    });
+
+    scans.initialize('scanlogs.json', 'campaigns.json');
+
+    const req = {
+      query: { uuid: '123', location_id: 'loc1', scan_type: 'test' }
+    };
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn(),
+      json: jest.fn()
+    };
+
+    scans.processScan(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(blockchainModule.recordScanOnBlockchain).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest unit test for passage-mode scan limit
- configure package.json test script to run Jest

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c3abbbc0832aba2c15629929f832