### PR TITLE
Add recent actions summary on admin page

### DIFF
--- a/modules/scans.js
+++ b/modules/scans.js
@@ -38,7 +38,7 @@ exports.getLogs = function(req, res) {
       const logs = JSON.parse(fs.readFileSync(scanLogFile, 'utf8'));
       
       // Options de filtrage (facultatives)
-      const { type, location, from, to } = req.query;
+  const { type, location, from, to, limit } = req.query;
       
       let filteredLogs = logs;
       
@@ -65,7 +65,16 @@ exports.getLogs = function(req, res) {
       }
       
       console.log(`Logs filtrés: ${filteredLogs.length}/${logs.length}`);
-      
+
+      if (limit) {
+        const n = parseInt(limit, 10);
+        if (!isNaN(n) && n > 0) {
+          filteredLogs = filteredLogs
+            .sort((a, b) => b.timestamp - a.timestamp)
+            .slice(0, n);
+        }
+      }
+
       res.json(filteredLogs);
     } else {
       console.log("⚠️ Fichier de logs non trouvé");

--- a/public/admin.html
+++ b/public/admin.html
@@ -88,6 +88,11 @@ function showCenterMessage(text, duration = 3000) {
   <div id="error-message"></div>
   <div id="status-message"></div>
 
+  <div class="recent-actions-section">
+    <h2>Dernières actions</h2>
+    <ul id="recent-actions-list" class="recent-actions-list"></ul>
+  </div>
+
 
   <div class="campaigns-section">
     <div class="campaigns-header">

--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -4217,3 +4217,19 @@ button > span:first-child {
 .mb-2 { margin-bottom: 16px; }
 .mb-3 { margin-bottom: 24px; }
 
+/* Section des dernières actions */
+.recent-actions-section {
+  margin: 20px 0;
+}
+
+.recent-actions-list {
+  list-style: none;
+  padding: 0;
+}
+
+.recent-actions-list li {
+  padding: 4px 0;
+  border-bottom: 1px solid #eee;
+  font-size: 13px;
+}
+

--- a/public/js/admin/ui.js
+++ b/public/js/admin/ui.js
@@ -3,10 +3,13 @@ let proofFiles = [];
 // Fonctions d'interface utilisateur et de manipulation DOM
 document.addEventListener('DOMContentLoaded', function() {
 
-  
+
   // Charger les campagnes
   console.log("Chargement initial des campagnes...");
   loadCampaigns();
+
+  // Charger les dernières actions
+  loadRecentActions();
 });
 
 // Afficher les erreurs de manière visible
@@ -26,6 +29,27 @@ function showStatus(message) {
     statusDiv.style.display = 'none';
   }, 3000);
   console.log(message);
+}
+
+// Charger les dernières actions depuis le serveur
+function loadRecentActions() {
+  const list = document.getElementById('recent-actions-list');
+  if (!list) return;
+
+  fetch(`${SERVER_URL}/scanlogs?limit=5`)
+    .then(res => res.json())
+    .then(actions => {
+      list.innerHTML = '';
+      actions.forEach(act => {
+        const li = document.createElement('li');
+        const date = new Date(act.timestamp * 1000).toLocaleString('fr-FR');
+        li.textContent = `[${date}] ${act.scan_type} - ${act.location_id} - ${act.uuid}`;
+        list.appendChild(li);
+      });
+    })
+    .catch(err => {
+      console.error('Erreur chargement actions:', err);
+    });
 }
 // Structure HTML complète corrigée pour openCampaignPopup
 


### PR DESCRIPTION
## Summary
- add `limit` param to `getLogs` for retrieving latest logs
- show recent actions on admin page
- fetch recent actions via `loadRecentActions()`
- style recent actions section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840ca3d01d4832a885874c900243419